### PR TITLE
Rest API - Ability to use SSL/TLS without self-signed certificate

### DIFF
--- a/src/main/java/io/bokun/inventory/plugin/harness/RestUtil.java
+++ b/src/main/java/io/bokun/inventory/plugin/harness/RestUtil.java
@@ -106,8 +106,7 @@ public class RestUtil {
         if (!nullToEmpty(pluginData.restBasicAuthUsername).isEmpty()) {
             httpClient.setAuthenticator(getRestHttpAuthenticator(pluginData.restBasicAuthUsername, pluginData.restBasicAuthPassword));
         }
-        if (pluginData.tls) {
-            assert pluginData.cert != null;
+        if (pluginData.tls && pluginData.cert != null) {
             acceptSelfSignedCertificate(httpClient, pluginData.cert);
         }
         return httpClient;


### PR DESCRIPTION
When USE_TLS is set and SSL_CERT_FILE is unset, it was showing:

`Exception in thread "main" java.lang.NullPointerException at io.bokun.inventory.plugin.harness.RestUtil.sendHttpRequestAndParseResponseArray(RestUtil.java:95)`